### PR TITLE
feat: Wordpress Component

### DIFF
--- a/src/components/cloud-run-wordpress.ts
+++ b/src/components/cloud-run-wordpress.ts
@@ -22,11 +22,6 @@ export interface CloudRunWordpressConfig {
   readonly databaseDiskSize?: pulumi.Input<number>;
 
   /**
-   * Turn on Wordpress Debug
-   */
-  readonly wordpressDebug?: pulumi.Input<boolean>;
-
-  /**
    * For Bedrock
    * Domain environment
    */
@@ -43,6 +38,14 @@ export interface CloudRunWordpressConfig {
    */
   readonly envs?: pulumi.Input<gcp.types.input.cloudrun.ServiceTemplateSpecContainerEnv>[];
 }
+
+const escapeName = (name: string) => {
+  name = name.replace(/[^\w\*]/g, '').toLowerCase();
+  if (name.length < 8) {
+    name = `${name}wordpress`;
+  }
+  return name.substring(0, 28);
+};
 
 export class CloudRunWordpress extends pulumi.ComponentResource {
   readonly service: gcp.cloudrun.Service;
@@ -81,16 +84,10 @@ export class CloudRunWordpress extends pulumi.ComponentResource {
       { parent: this },
     );
 
-    const serviceAccountName = new random.RandomString(
-      name,
-      { length: 10, special: false, upper: false, number: false },
-      { parent: this },
-    );
-
     this.serviceAccount = new ServiceAccount(
       name,
       {
-        accountId: serviceAccountName.result,
+        accountId: escapeName(name),
         roles: ['roles/cloudsql.client'],
       },
       { parent: this },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './components';
+export * from './wordpress';

--- a/src/wordpress.ts
+++ b/src/wordpress.ts
@@ -1,0 +1,67 @@
+import * as pulumi from '@pulumi/pulumi';
+import { ApiServices, CloudRunWordpress, GCRDocker } from './components';
+
+export interface WordpressArgs {
+  /**
+   * Domain for this project
+   */
+  readonly domain: string;
+  /**
+   * Database storage in gigabytes (minimum 10)
+   * @default 10
+   */
+  readonly databaseDiskSize?: number;
+  /**
+   * Activate backups (automated database backups)
+   */
+  readonly activateBackups?: boolean;
+  /**
+   * Size of project
+   * Used for setting up sensible defaults
+   * @default small
+   */
+  readonly size: 'small' | 'medium' | 'large';
+  /**
+   * The location of the cloud run instance. eg us-central1
+   */
+  readonly location: pulumi.Input<string>;
+  /**
+   * Folder where your Dockerfile are
+   * located.
+   * @default ../site
+   */
+  readonly build?: string;
+}
+
+
+export class Wordpress extends pulumi.ComponentResource {
+  readonly apiServices: ApiServices;
+  readonly gcrDocker: GCRDocker;
+  readonly service: CloudRunWordpress;
+
+  constructor(
+    name: string,
+    args: WordpressArgs,
+    opts: pulumi.ComponentResourceOptions = {},
+  ) {
+    super('wordpress', name, args, opts);
+
+    const { build = '../site', location, databaseDiskSize } = args;
+
+    this.apiServices = new ApiServices(name, {});
+
+    this.gcrDocker = new GCRDocker(
+      name,
+      {
+        build,
+      },
+      { parent: this, dependsOn: this.apiServices },
+    );
+
+    this.service = new CloudRunWordpress(name, {
+      image: this.gcrDocker.image.imageName,
+      location,
+      databaseDiskSize,
+    });
+  }
+}


### PR DESCRIPTION
fixes #5

```typescript
import * as pw from 'pulumi-wordpress';

new pw.Wordpress(
  'project-name', // Name
  {
    // Domain for this project
    domain: 'vg.no',
    // Database storage in gigabytes (minimum 10)
    databaseDiskSize: 10,
    // Activate backups
    activateBackups: true,
    // size of project
    size: 'small',
    // location
    location: 'europe-west3',
    // build
    build: '../site',
  }
);
```

I did some changes, but it is basically the same as in #5. 

## TODO

- [ ] Add activate backups functionality.


cc: @AnneMatilde